### PR TITLE
🎨 Palette: Add form autocomplete & mobile input modes

### DIFF
--- a/src/lib/components/JoinForm.svelte
+++ b/src/lib/components/JoinForm.svelte
@@ -171,6 +171,9 @@
 												id="zip"
 												bind:value={zipCode}
 												placeholder="Enter 5-digit ZIP Code"
+												autocomplete="postal-code"
+												inputmode="numeric"
+												pattern="[0-9]*"
 												class="flex-1 bg-charcoal border border-white/20 text-bone px-4 py-2 rounded-md focus:border-crimson outline-none transition-colors"
 												maxlength="5"
 												oninput={() => (error = '')}
@@ -257,6 +260,7 @@
 							<input
 								type="text"
 								id="firstName"
+								autocomplete="given-name"
 								bind:this={firstNameInput}
 								bind:value={registrationState.form.firstName}
 								required
@@ -271,6 +275,7 @@
 							<input
 								type="text"
 								id="lastName"
+								autocomplete="family-name"
 								bind:value={registrationState.form.lastName}
 								required
 								class="w-full bg-charcoal border border-white/20 text-bone px-4 py-2 rounded-md focus:outline-none focus:border-crimson transition-colors"
@@ -284,6 +289,7 @@
 							<input
 								type="email"
 								id="email"
+								autocomplete="email"
 								bind:value={registrationState.form.email}
 								required
 								class="w-full bg-charcoal border border-white/20 text-bone px-4 py-2 rounded-md focus:outline-none focus:border-crimson transition-colors"
@@ -298,6 +304,7 @@
 							<input
 								type="tel"
 								id="phone"
+								autocomplete="tel"
 								bind:value={registrationState.form.phone}
 								class="w-full bg-charcoal border border-white/20 text-bone px-4 py-2 rounded-md focus:outline-none focus:border-crimson transition-colors"
 							/>

--- a/tests/join-form-ux.spec.ts
+++ b/tests/join-form-ux.spec.ts
@@ -1,59 +1,71 @@
 import { test, expect } from '@playwright/test';
 
 test('Join Form UX improvements', async ({ page }) => {
-  await page.goto('/join');
+	await page.goto('/join');
 
-  // STEP 1: District Finder
-  await page.getByPlaceholder('Enter 5-digit ZIP Code').fill('30030');
-  await page.getByRole('button', { name: 'Find' }).click();
+	// STEP 1: District Finder
+	// CHECK: ZIP Input attributes
+	const zipInput = page.getByPlaceholder('Enter 5-digit ZIP Code');
+	await expect(zipInput).toHaveAttribute('autocomplete', 'postal-code');
+	await expect(zipInput).toHaveAttribute('inputmode', 'numeric');
+	await expect(zipInput).toHaveAttribute('pattern', '[0-9]*');
 
-  // Wait for result
-  await expect(page.getByText('Your Georgia House District is:')).toBeVisible();
+	await zipInput.fill('30030');
+	await page.getByRole('button', { name: 'Find' }).click();
 
-  // CHECK 1: Focus Management on Result
-  // The focus should move to the result container or the "Not your district?" button
-  const resultContainer = page.locator('.text-center.bg-charcoal\\/50');
-  const notYourDistrictBtn = page.getByRole('button', { name: 'Not your district?' });
+	// Wait for result
+	await expect(page.getByText('Your Georgia House District is:')).toBeVisible();
 
-  // We expect one of them to be focused.
-  // Since .or() with toBeFocused might be tricky, let's check active element
-  // await expect(resultContainer.or(notYourDistrictBtn)).toBeFocused();
-  // Actually Playwright's expect(locator).toBeFocused() works on a single locator.
-  // We'll target the container for now as the plan is to focus that or the first focusable element inside.
-  // Let's verify if the container is focused.
-  await expect(resultContainer).toBeFocused();
+	// CHECK 1: Focus Management on Result
+	// The focus should move to the result container or the "Not your district?" button
+	const resultContainer = page.locator('.text-center.bg-charcoal\\/50');
+	const notYourDistrictBtn = page.getByRole('button', { name: 'Not your district?' });
 
-  // Proceed to Step 2
-  await page.getByRole('button', { name: 'Next' }).click();
+	// We expect one of them to be focused.
+	// Since .or() with toBeFocused might be tricky, let's check active element
+	// await expect(resultContainer.or(notYourDistrictBtn)).toBeFocused();
+	// Actually Playwright's expect(locator).toBeFocused() works on a single locator.
+	// We'll target the container for now as the plan is to focus that or the first focusable element inside.
+	// Let's verify if the container is focused.
+	await expect(resultContainer).toBeFocused();
 
-  // CHECK 2: Focus Management on Step Change
-  // Focus should be on First Name input
-  await expect(page.getByLabel('First Name')).toBeFocused();
+	// Proceed to Step 2
+	await page.getByRole('button', { name: 'Next' }).click();
 
-  // CHECK 3: Validation on Step 2
-  // Try to click Next without filling anything
-  const nextButtonStep2 = page.getByRole('button', { name: 'Next' }).last();
-  // Note: There are two "Next" buttons in the DOM because of the transition?
-  // No, Step 1 Next is hidden/removed. But let's be safe.
+	// CHECK 2: Focus Management on Step Change
+	// Focus should be on First Name input
+	await expect(page.getByLabel('First Name')).toBeFocused();
 
-  await nextButtonStep2.click();
+	// CHECK: Step 2 Input Attributes
+	await expect(page.getByLabel('First Name')).toHaveAttribute('autocomplete', 'given-name');
+	await expect(page.getByLabel('Last Name')).toHaveAttribute('autocomplete', 'family-name');
+	await expect(page.getByLabel('Email')).toHaveAttribute('autocomplete', 'email');
+	await expect(page.getByLabel('Cell (Optional)')).toHaveAttribute('autocomplete', 'tel');
 
-  // We should NOT see "Home Church" (Step 3)
-  await expect(page.getByLabel('Home Church')).not.toBeVisible();
+	// CHECK 3: Validation on Step 2
+	// Try to click Next without filling anything
+	const nextButtonStep2 = page.getByRole('button', { name: 'Next' }).last();
+	// Note: There are two "Next" buttons in the DOM because of the transition?
+	// No, Step 1 Next is hidden/removed. But let's be safe.
 
-  // We SHOULD see the error message
-  await expect(page.getByRole('alert')).toHaveText('Please fill in all required fields.');
+	await nextButtonStep2.click();
 
-  // Fill valid data
-  await page.getByLabel('First Name').fill('John');
-  await page.getByLabel('Last Name').fill('Doe');
-  await page.getByLabel('Email').fill('john@example.com');
+	// We should NOT see "Home Church" (Step 3)
+	await expect(page.getByLabel('Home Church')).not.toBeVisible();
 
-  await nextButtonStep2.click();
+	// We SHOULD see the error message
+	await expect(page.getByRole('alert')).toHaveText('Please fill in all required fields.');
 
-  // Now Step 3 should be visible
-  await expect(page.getByLabel('Home Church')).toBeVisible();
+	// Fill valid data
+	await page.getByLabel('First Name').fill('John');
+	await page.getByLabel('Last Name').fill('Doe');
+	await page.getByLabel('Email').fill('john@example.com');
 
-  // CHECK 4: Focus Management on Step 3
-  await expect(page.getByLabel('Home Church')).toBeFocused();
+	await nextButtonStep2.click();
+
+	// Now Step 3 should be visible
+	await expect(page.getByLabel('Home Church')).toBeVisible();
+
+	// CHECK 4: Focus Management on Step 3
+	await expect(page.getByLabel('Home Church')).toBeFocused();
 });

--- a/tests/verify.spec.ts
+++ b/tests/verify.spec.ts
@@ -1,6 +1,0 @@
-import { test, expect } from '@playwright/test';
-
-test('verify bill analysis page', async ({ page }) => {
-  await page.goto('/bill-analysis');
-  await page.screenshot({ path: '/home/jules/verification/verification.png', fullPage: true });
-});


### PR DESCRIPTION
🎨 **Palette UX Improvement**

**What:** Added `autocomplete`, `inputmode`, and `pattern` attributes to the Join Form inputs.

**Why:**
- Mobile users were seeing a standard text keyboard for the ZIP code field. Adding `inputmode="numeric"` ensures they get a numeric keypad, making entry much faster.
- Browsers couldn't confidently autofill personal information. Adding standard `autocomplete` tokens (`given-name`, `family-name`, `email`, `tel`, `postal-code`) allows users to fill the form with a single tap.

**Accessibility:**
- Helps cognitive load by reducing typing.
- Improves error prevention by using standard browser mechanisms.

**Testing:**
- Updated `tests/join-form-ux.spec.ts` to assert the presence of these attributes.
- Verified tests pass.


---
*PR created automatically by Jules for task [2370276274228935195](https://jules.google.com/task/2370276274228935195) started by @skylerahuman*