### PR TITLE
⚡ Bolt: Optimize IntersectionObserver state batching and timeline data loading

### DIFF
--- a/src/routes/georgia-battle/+page.svelte
+++ b/src/routes/georgia-battle/+page.svelte
@@ -1,6 +1,7 @@
 <script lang="ts">
 	import { base } from '$app/paths';
 	import { onMount } from 'svelte';
+	import timelineData from '$lib/data/timeline.json';
 	
 	interface TimelineEvent {
 		id: string;
@@ -12,7 +13,8 @@
 		linkText?: string;
 	}
 	
-	let timeline = $state<TimelineEvent[]>([]);
+	// Initialize timeline synchronously
+	let timeline = $state<TimelineEvent[]>(timelineData as TimelineEvent[]);
 	let visibleCards = $state<Set<string>>(new Set());
 	let copied = $state(false);
 
@@ -27,35 +29,38 @@
 			console.error("Share: Clipboard write failed", e);
 		}
 	}
-	
+
 	onMount(() => {
+
 		let observer: IntersectionObserver;
 
-		const init = async () => {
-			const response = await fetch(`${base}/data/timeline.json`);
-			timeline = await response.json();
+		// Setup intersection observer for staggered animations
+		observer = new IntersectionObserver(
+			(entries) => {
+				let hasChanges = false;
+				const newVisibleCards = new Set(visibleCards);
 
-			// Setup intersection observer for staggered animations
-			observer = new IntersectionObserver(
-				(entries) => {
-					entries.forEach(entry => {
-						if (entry.isIntersecting) {
-							const id = entry.target.getAttribute('data-id');
-							if (id) {
-								visibleCards = new Set([...visibleCards, id]);
-							}
+				entries.forEach(entry => {
+					if (entry.isIntersecting) {
+						const id = entry.target.getAttribute('data-id');
+						if (id && !newVisibleCards.has(id)) {
+							newVisibleCards.add(id);
+							hasChanges = true;
+							observer.unobserve(entry.target); // Optional: Stop observing once visible to save performance
 						}
-					});
-				},
-				{ threshold: 0.2 }
-			);
+					}
+				});
 
-			document.querySelectorAll('.timeline-card').forEach(card => {
-				observer.observe(card);
-			});
-		};
-		
-		init();
+				if (hasChanges) {
+					visibleCards = newVisibleCards;
+				}
+			},
+			{ threshold: 0.2 }
+		);
+
+		document.querySelectorAll('.timeline-card').forEach(card => {
+			observer.observe(card);
+		});
 		
 		return () => {
 			if (observer) observer.disconnect();


### PR DESCRIPTION
💡 What: Implemented performance optimizations for `georgia-battle/+page.svelte`:
- Moved `fetch('timeline.json')` to a synchronous static import, preventing a network request and layout shift (LCP).
- Batched Svelte reactive updates within the `IntersectionObserver` `forEach` loop. Instead of `visibleCards` reacting multiple times for each intersecting element, changes are collected and applied once.
- Added `observer.unobserve` for already-rendered cards to optimize background memory usage and lower layout observation triggers.

🎯 Why: 
- Eliminates client-side waterfall and layout thrashing (Svelte re-rendering explosion) that happens when multiple elements become visible simultaneously.

📊 Impact: 
- Zero network requests to render `timeline.json`.
- Dramatically reduces DOM layout and repaint thrashing from reactive states inside observer loops. Reduces re-renders.

🔬 Measurement: 
- Playwright and manual script tests pass seamlessly with the cards still dynamically lazy loading their animations properly. Svelte reactivity isn't blocked by network delays anymore.

---
*PR created automatically by Jules for task [14256743456272769247](https://jules.google.com/task/14256743456272769247) started by @skylerahuman*