### PR TITLE
⚡ Bolt: Optimize IntersectionObserver batching & stop persistent watch on Georgia Battle

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -19,3 +19,8 @@
 
 2. `background-attachment: fixed` causes constant repaints on mobile during scroll.
    **Action:** Use a fixed-position pseudo-element (`position: fixed; z-index: -1`) with `will-change: transform` to achieve the same visual effect while keeping the layer on the compositor.
+
+## 2025-02-18 - IntersectionObserver Persistent Watching
+
+**Learning:** `IntersectionObserver` elements continue to fire intersection events even after they have appeared on screen, adding unnecessary overhead on scroll if only a one-time animation was needed.
+**Action:** When using `IntersectionObserver` for one-time effects like fade-ins, always call `observer.unobserve(entry.target)` once the condition is met to remove it from the watch list.

--- a/src/routes/georgia-battle/+page.svelte
+++ b/src/routes/georgia-battle/+page.svelte
@@ -38,14 +38,23 @@
 			// Setup intersection observer for staggered animations
 			observer = new IntersectionObserver(
 				(entries) => {
+					let hasUpdates = false;
+					const newVisibleCards = new Set(visibleCards);
+
 					entries.forEach(entry => {
 						if (entry.isIntersecting) {
 							const id = entry.target.getAttribute('data-id');
-							if (id) {
-								visibleCards = new Set([...visibleCards, id]);
+							if (id && !newVisibleCards.has(id)) {
+								newVisibleCards.add(id);
+								hasUpdates = true;
+								observer.unobserve(entry.target); // Optimization: Stop observing once visible
 							}
 						}
 					});
+
+					if (hasUpdates) {
+						visibleCards = newVisibleCards; // Single reactivity trigger
+					}
 				},
 				{ threshold: 0.2 }
 			);


### PR DESCRIPTION
💡 What:
Optimized the `IntersectionObserver` callback in `georgia-battle/+page.svelte` to batch state updates and unobserve elements once they are visible.

🎯 Why:
Inside the loop handling intersections (`entries.forEach`), the reactive `$state` `visibleCards` was being updated repeatedly (e.g., `visibleCards = new Set(...)`). When multiple cards intersected at once (which is common on initial load or fast scrolling), this caused Svelte to trigger re-renders multiple times synchronously, resulting in layout thrashing. Furthermore, elements continued to be tracked by the observer after their one-time fade-in animation, causing unnecessary overhead on scroll events.

📊 Impact:
- **Reduces re-renders**: Reactivity is triggered only once per intersection batch, regardless of how many elements are intersecting at once.
- **Reduces main thread overhead**: Elements that have already animated in are unobserved, meaning the browser no longer needs to evaluate their intersection status during scrolling.

🔬 Measurement:
Verified via `pnpm test` that the functionality remains identical and timeline animations still trigger correctly. Code review requested and approved. Also added this critical learning about `unobserve` to the `bolt.md` journal.

---
*PR created automatically by Jules for task [6250579925573776910](https://jules.google.com/task/6250579925573776910) started by @skylerahuman*