### PR TITLE
🎨 Palette: Fix ExegesisModal Accessibility

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -7,3 +7,7 @@
 
 **Learning:** Custom toggle buttons (like donation amounts) need `aria-pressed` to communicate state to screen readers, and design-heavy inputs (like custom amounts with currency symbols) often lack visible labels, requiring `aria-label`.
 **Action:** When implementing custom selection UIs or inputs without standard labels, always add `aria-pressed` or `aria-label` to ensure screen reader users aren't left guessing.
+
+## 2026-03-06 - Svelte 5 Modal Accessibility
+**Learning:** Using `role="document"` instead of `role="dialog"` for modals breaks screen reader accessibility and causes DOM-testing-library (e.g. `@testing-library/svelte`) queries like `getByRole('dialog')` to fail.
+**Action:** Always use `role="dialog"` along with `aria-modal="true"` and `aria-labelledby` pointing to the modal title ID for accessible modal dialogs.

--- a/src/lib/components/ExegesisModal.svelte
+++ b/src/lib/components/ExegesisModal.svelte
@@ -47,7 +47,9 @@
 	>
 		<div
 			class="bg-navy-light border border-gold/20 rounded-xl shadow-2xl max-w-2xl w-full max-h-[80vh] flex flex-col"
-			role="document"
+			role="dialog"
+			aria-modal="true"
+			aria-labelledby="modal-title"
 			tabindex="-1"
 			onclick={(e) => e.stopPropagation()}
 			onkeydown={(e) => e.stopPropagation()}


### PR DESCRIPTION
💡 **What:** Added proper ARIA attributes and changed the structural element role of `ExegesisModal.svelte` from `document` to `dialog`. Also added a `.jules/palette.md` entry to journal this fix.
🎯 **Why:** To make the modal screen-reader accessible and conformant with correct ARIA standard patterns. This fixes failing DOM-testing-library queries such as `getByRole('dialog')`.
♿ **Accessibility:** Screen readers will now trap focus contexts correctly inside the dialog and announce the modal appropriately due to `aria-modal` and `aria-labelledby`.

---
*PR created automatically by Jules for task [10040817455224622100](https://jules.google.com/task/10040817455224622100) started by @skylerahuman*