### PR TITLE
🎨 Palette: Improve FAQ accordion accessibility and focus states

### DIFF
--- a/src/routes/faqs/+page.svelte
+++ b/src/routes/faqs/+page.svelte
@@ -125,7 +125,9 @@
 			<div class="bg-panel rounded-lg shadow-md overflow-hidden border border-white/10">
 				<button
 					onclick={() => toggleFaq(i)}
-					class="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-white/5 transition-colors duration-200"
+					aria-expanded={openFaq === i}
+					aria-controls="faq-content-{i}"
+					class="w-full px-6 py-4 text-left flex justify-between items-center hover:bg-white/5 transition-colors duration-200 focus:outline-none focus-visible:ring-2 focus-visible:ring-crimson/50"
 				>
 					<span class="text-lg font-semibold text-bone pr-4">
 						{faq.question}
@@ -146,7 +148,7 @@
 				</button>
 
 				{#if openFaq === i}
-					<div class="px-6 pb-4">
+					<div id="faq-content-{i}" class="px-6 pb-4">
 						<div class="text-bone/70 whitespace-pre-line mb-4">
 							{faq.answer}
 						</div>


### PR DESCRIPTION
* 💡 What: Added `aria-expanded` and `aria-controls` attributes to the FAQ toggle buttons and their corresponding content panels. Also added `focus-visible` styles (`ring-2`) to the buttons.
* 🎯 Why: This ensures screen readers can correctly announce the expanded/collapsed state of the FAQs and logically link the button to the content it reveals. The focus ring improves keyboard navigation visibility without impacting mouse users.
* 📸 Before/After: Visual changes were minimal, but keyboard tabbing now shows a visible red ring around the active FAQ item.
* ♿ Accessibility: Improved screen reader announcements and keyboard navigation for the FAQ accordion.

---
*PR created automatically by Jules for task [6559392834161895537](https://jules.google.com/task/6559392834161895537) started by @skylerahuman*